### PR TITLE
profile画像を記事詳細画面で表示

### DIFF
--- a/app/Dto/ArticleDetailDto.php
+++ b/app/Dto/ArticleDetailDto.php
@@ -17,6 +17,7 @@ class ArticleDetailDto
         public string  $body,
         public int     $userId,
         public string  $userName,
+        public string  $profileImagePath,
         public ?string $thumbnailPath,
         public array   $categories,
         public array   $imagePaths

--- a/app/Repository/ArticleDetailRepository.php
+++ b/app/Repository/ArticleDetailRepository.php
@@ -70,6 +70,7 @@ class ArticleDetailRepository implements RepositoryInterface
             articles.body, 
             articles.user_id, 
             users.name AS user_name,
+            users.profile_image_path AS profile_image_path,
             thumbnails.path AS thumbnail_path,
             COALESCE(category_ids.category_ids, '{}') AS category_ids,
             COALESCE(image_paths.image_paths, '{}') AS image_paths
@@ -100,6 +101,7 @@ class ArticleDetailRepository implements RepositoryInterface
         $body = $data['body'];
         $userId = (int)$data['user_id'];
         $userName = $data['user_name'];
+        $profileImagePath = $data['profile_image_path'];
         $thumbnailPath = $data['thumbnail_path'];
         $categories = [];
         $imagePaths = [];
@@ -122,6 +124,7 @@ class ArticleDetailRepository implements RepositoryInterface
             $body,
             $userId,
             $userName,
+            $profileImagePath,
             $thumbnailPath,
             $categories,
             $imagePaths

--- a/app/View/article_detail.php
+++ b/app/View/article_detail.php
@@ -12,7 +12,12 @@
     <div>Title:<?php echo htmlspecialchars($articleDetail->title); ?></div>
     <div>Body:<?php echo htmlspecialchars($articleDetail->body); ?></div>
     <div>UserID:<?php echo htmlspecialchars($articleDetail->userId); ?></div>
-    <div>UserName:<?php echo htmlspecialchars($articleDetail->userName); ?></div>
+    <div style="display: flex; align-items: center;">
+        <?php if (!empty($articleDetail->profileImagePath)): ?>
+            <img src="<?= htmlspecialchars($articleDetail->profileImagePath, ENT_QUOTES, 'UTF-8') ?>" alt="ProfileImage" style="width:100px;height:100px;border-radius:50%; margin-right: 10px;">
+        <?php endif; ?>
+        <p>UserName: <?= nl2br(htmlspecialchars($articleDetail->userName, ENT_QUOTES, 'UTF-8')) ?></p>
+    </div>
     <?php if (!empty($articleDetail->thumbnailPath)): ?>
         <img src="<?= htmlspecialchars($articleDetail->thumbnailPath, ENT_QUOTES, 'UTF-8') ?>" alt="Thumbnail" style="width:100px;height:100px;">
     <?php endif; ?>


### PR DESCRIPTION
profile画像を記事詳細画面で表示できるようにしました。
前PRと同様に丸画像がプロフィール画像です

![image](https://github.com/kojikokojiko/kensyu-php/assets/48917379/e65d79c8-7d9c-4690-a0bb-5d851f3b4139)
